### PR TITLE
The total amount of cart did not include the quantity of the product

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -205,7 +205,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         # Note, we don't include discounts here - they are handled as separate
         # lines - see below
         params['L_PAYMENTREQUEST_0_AMT%d' % index] = _format_currency(
-            line.unit_price_incl_tax)
+            line.line_price_incl_tax)
         params['L_PAYMENTREQUEST_0_QTY%d' % index] = line.quantity
 
     # If the order has discounts associated with it, the way PayPal suggests


### PR DESCRIPTION
@monokrome  : 
The Error : If we add more than one quantity of the same product in the cart, it threw an exception. 
The reason being,  L_PAYMENTREQUEST_0_AMT was not taking into account the quantities of the product.. And it threw an exception because the total of the cart items did not match the order amount. Thus changed unit price to line price to include the total amount. 
