### PR TITLE
fix as it would not load the object for anonymous users

### DIFF
--- a/paypal/__init__.py
+++ b/paypal/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.9.8'
+VERSION = '0.9.9'

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -222,7 +222,7 @@ class SuccessResponseView(PaymentDetailsView):
     def load_frozen_basket(self, basket_id):
         # Lookup the frozen basket that this txn corresponds to
         try:
-            basket = Basket.objects.get(id=basket_id, status=Basket.FROZEN, owner=self.request.user)
+            basket = Basket.objects.get(id=basket_id, status=Basket.FROZEN)
         except Basket.DoesNotExist:
             return None
 

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -150,7 +150,7 @@ class CancelResponseView(RedirectView):
 
     def get(self, request, *args, **kwargs):
         basket = get_object_or_404(Basket, id=kwargs['basket_id'],
-                                    owner=self.request.user, status=Basket.FROZEN)
+                                    status=Basket.FROZEN)
 
         basket.thaw()
         logger.info("Payment cancelled (token %s) - basket #%s thawed",


### PR DESCRIPTION
putting it back as it was. And aims to fix:`int() argument must be a string or a number, not 'SimpleLazyObject'` that occurs for anonymous users.
